### PR TITLE
[FIX] Decorators polyfill

### DIFF
--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -34,6 +34,7 @@
     "ember-cli-sass": "^10.0.0",
     "ember-css-transitions": "^0.1.16",
     "ember-decorators": "^6.1.1",
+    "ember-decorators-polyfill": "^1.1.1",
     "ember-svg-jar": "^2.1.0",
     "ember-template-lint": "^1.6.0",
     "ember-truth-helpers": "^2.1.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -33,6 +33,7 @@
     "ember-cli-sass": "^10.0.0",
     "ember-css-transitions": "^0.1.16",
     "ember-decorators": "^6.1.1",
+    "ember-decorators-polyfill": "^1.1.1",
     "ember-svg-jar": "^2.1.0",
     "ember-template-lint": "^1.6.0",
     "ember-truth-helpers": "^2.1.0",

--- a/packages/inline-banner/package.json
+++ b/packages/inline-banner/package.json
@@ -32,6 +32,7 @@
     "ember-cli-sass": "^10.0.0",
     "ember-css-transitions": "^0.1.16",
     "ember-decorators": "^6.1.1",
+    "ember-decorators-polyfill": "^1.1.1",
     "ember-svg-jar": "^2.1.0",
     "ember-template-lint": "^1.6.0",
     "ember-truth-helpers": "^2.1.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -34,6 +34,7 @@
     "ember-cli-sass": "^10.0.0",
     "ember-css-transitions": "^0.1.16",
     "ember-decorators": "^6.1.1",
+    "ember-decorators-polyfill": "^1.1.1",
     "ember-svg-jar": "^2.1.0",
     "ember-template-lint": "^1.6.0",
     "ember-truth-helpers": "^2.1.0",

--- a/packages/toast-message/package.json
+++ b/packages/toast-message/package.json
@@ -35,6 +35,7 @@
     "ember-cli-sass": "^10.0.0",
     "ember-css-transitions": "^0.1.16",
     "ember-decorators": "^6.1.1",
+    "ember-decorators-polyfill": "^1.1.1",
     "ember-svg-jar": "^2.1.0",
     "ember-template-lint": "^1.6.0",
     "ember-truth-helpers": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6328,6 +6328,15 @@ ember-css-transitions@^0.1.16:
     ember-cli-typescript "^2.0.2"
     ember-inflector "^3.0.1"
 
+ember-decorators-polyfill@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.1.tgz#6ff8e57a516e04c583451305574020c34e6ad4bc"
+  integrity sha512-ZIB3uNcquNyRm+eWUbDeeE5BtH/D7oXIX9pdiEHx4TXaTnAY6z4wDrw6Ge0xP9wx/nlC4Qd/i8rdlwBOT5C6lw==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+    ember-cli-version-checker "^3.1.3"
+    ember-compatibility-helpers "^1.2.0"
+
 ember-decorators@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-6.1.1.tgz#6d770f8999cf5a413a1ee459afd520838c0fc470"


### PR DESCRIPTION
ember v.2.18 to v.3.1 requires this polyfill for decorators to work properly.