### PR TITLE
fix(banner): Removed htmlSafe

### DIFF
--- a/packages/inline-banner/addon/components/nucleus-inline-banner.js
+++ b/packages/inline-banner/addon/components/nucleus-inline-banner.js
@@ -72,17 +72,6 @@ class NucleusInlineBanner extends Component {
   title = null;
 
   /**
-  * _title
-  *
-  * @computed _title
-  * @private
-  */
-  @computed('title', function () {
-    return this.get('title');
-  })
-  _title;
-
-  /**
   * _typeClass
   *
   * @computed _typeClass

--- a/packages/inline-banner/addon/components/nucleus-inline-banner.js
+++ b/packages/inline-banner/addon/components/nucleus-inline-banner.js
@@ -3,7 +3,6 @@ import { classNames, attributeBindings, classNameBindings, layout as templateLay
 import Component from '@ember/component';
 import { set, action } from '@ember/object';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/template';
 import layout from '../templates/components/nucleus-inline-banner';
 import { ICON_MAP } from '../constants/nucleus-inline-banner';
 
@@ -79,7 +78,7 @@ class NucleusInlineBanner extends Component {
   * @private
   */
   @computed('title', function () {
-    return htmlSafe(this.get('title'));
+    return this.get('title');
   })
   _title;
 

--- a/packages/inline-banner/addon/templates/components/nucleus-inline-banner.hbs
+++ b/packages/inline-banner/addon/templates/components/nucleus-inline-banner.hbs
@@ -9,7 +9,7 @@
     {{nucleus-icon name=_icon size="medium"}}
   </div>
   <div class="nucleus-inline-banner__content">
-    <div data-test-id="nucleus-inline-banner-title">{{_title}}</div>
+    <div data-test-id="nucleus-inline-banner-title">{{title}}</div>
   </div>
   {{#if isDismissible}}
     <div class="nucleus-inline-banner__close">


### PR DESCRIPTION
Resolves a potential security issue. 

If required, `htmlSafe` has to be done by the component invoking `nucleus-inline-banner` but not within banner itself.