### PR TITLE
fix: button icon variant

### DIFF
--- a/packages/@nucleus/tests/dummy/app/templates/docs/components/nucleus-button.md
+++ b/packages/@nucleus/tests/dummy/app/templates/docs/components/nucleus-button.md
@@ -76,7 +76,9 @@ The `iconSize` property specifies the size of the icon. If the iconSize is not m
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='nucleus-button-icon.hbs'}}
-    {{nucleus-button icon="nucleus-circle-check" label="Click here" variant="danger"}}
+    {{nucleus-button icon="nucleus-circle-help" label="Click here" variant="primary"}}
+    {{nucleus-button icon="nucleus-circle-check" label="Click here" variant="secondary"}}
+    {{nucleus-button icon="nucleus-circle-minus" label="Click here" variant="danger"}}
   {{/demo.example}}
   {{demo.snippet 'nucleus-button-icon.hbs'}}
 {{/docs-demo}}

--- a/packages/button/addon/components/nucleus-button.js
+++ b/packages/button/addon/components/nucleus-button.js
@@ -12,7 +12,7 @@ import { run } from '@ember/runloop';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from "../templates/components/nucleus-button";
-import { BUTTON_STATE } from "../constants/nucleus-button";
+import { BUTTON_STATE, ICON_VARIANT_MAP } from "../constants/nucleus-button";
 import safeSet from "../utils/safe-set";
 
 /**
@@ -94,6 +94,19 @@ class NucleusButton extends Component {
   */
   @defaultProp
   variant = 'primary';
+
+  /**
+  * Attribute bound to icon variant
+  *
+  * @field _iconVariant
+  * @type string
+  * @private
+  */
+  @computed('variant')
+  get _iconVariant() {
+    let variant = this.get('variant');
+    return ICON_VARIANT_MAP[variant];
+  }
 
   /**
   * Attribute bound to button type
@@ -406,13 +419,12 @@ class NucleusButton extends Component {
   */
   click() {
     let action = this.get('onClick');
-
     if (action === null || action === undefined) {
       return;
     }
 
     if (!this.get('_isPending')) {
-      let promise = action(this.get('args'));
+      let promise = (action)(this.get('args'));
 
       if (promise && typeof promise.then === 'function') {
         safeSet(this, '_buttonState', BUTTON_STATE.PENDING);

--- a/packages/button/addon/constants/nucleus-button.js
+++ b/packages/button/addon/constants/nucleus-button.js
@@ -5,4 +5,12 @@ const BUTTON_STATE = {
   REJECTED: "rejected"
 };
 
-export { BUTTON_STATE };
+const ICON_VARIANT_MAP = {
+  primary: "secondary",
+  secondary: "primary",
+  danger: "secondary",
+  text: "primary",
+  icon: "info"
+}
+
+export { BUTTON_STATE, ICON_VARIANT_MAP };

--- a/packages/button/addon/templates/components/nucleus-button.hbs
+++ b/packages/button/addon/templates/components/nucleus-button.hbs
@@ -1,4 +1,4 @@
-{{#if icon}}{{nucleus-icon name=icon size=_iconSize}}{{/if}}
+{{#if icon}}{{nucleus-icon name=icon size=_iconSize variant=_iconVariant}}{{/if}}
 {{#if (and _isLoading _isShowLoading)}}
   <div data-test-button-loader class="circle-loader {{if _isLoadingComplete "load-complete"}}">
     <div class="checkmark draw"></div>

--- a/packages/icon/addon/styles/addon.scss
+++ b/packages/icon/addon/styles/addon.scss
@@ -30,7 +30,7 @@
   }
 
   &--secondary {
-    fill: $text-secondary;
+    fill: $color-milk;
   }
 
   &--danger {

--- a/packages/toast-message/addon/components/nucleus-toast-message.js
+++ b/packages/toast-message/addon/components/nucleus-toast-message.js
@@ -3,7 +3,7 @@ import { layout as templateLayout } from '@ember-decorators/component';
 import { inject } from '@ember/service';
 import Component from '@ember/component';
 import layout from '../templates/components/nucleus-toast-message';
-import { ICON_MAP } from '../constants/nucleus-toast-message';
+import { ICON_MAP, VARIANT_MAP } from '../constants/nucleus-toast-message';
 
 /**
   __Usage:__
@@ -38,7 +38,23 @@ class NucleusToastMessage extends Component {
   @defaultProp
   position = 'top center';
 
+  /**
+  * Mapper to get the icon name from flashmessage.type
+  *
+  * @field _iconMap
+  * @type string
+  * @private
+  */
   _iconMap = ICON_MAP;
+
+  /**
+  * Mapper to get the icon variant from flashmessage.type
+  *
+  * @field _variantMap
+  * @type string
+  * @private
+  */
+  _variantMap = VARIANT_MAP;
 }
 
 export default NucleusToastMessage;

--- a/packages/toast-message/addon/constants/nucleus-toast-message.js
+++ b/packages/toast-message/addon/constants/nucleus-toast-message.js
@@ -5,4 +5,11 @@ const ICON_MAP = {
   'Danger': 'nucleus-circle-cross'
 };
 
-export { ICON_MAP };
+const VARIANT_MAP = {
+  'Info': 'info',
+  'Success': 'success',
+  'Warning': 'warning',
+  'Danger': 'danger'
+};
+
+export { ICON_MAP, VARIANT_MAP };

--- a/packages/toast-message/addon/templates/components/nucleus-toast-message.hbs
+++ b/packages/toast-message/addon/templates/components/nucleus-toast-message.hbs
@@ -2,7 +2,12 @@
   {{#each flashMessages.queue as |flash|}}
     {{#transition-group transitionClass="slide-down"}}
       {{#flash-message flash=flash class="nucleus-toast-message" as |component flash close|}}
-        <div class="nucleus-toast-message__icon">{{nucleus-icon name=(get _iconMap component.flashType) size="medium"}}</div>
+        <div class="nucleus-toast-message__icon">
+          {{nucleus-icon
+            name=(get _iconMap component.flashType)
+            variant=(get _variantMap component.flashType)
+            size="medium"}}
+        </div>
         <div class="nucleus-toast-message__content">
           <p class="title">{{flash.message}}</p>
           {{#if flash.content}}


### PR DESCRIPTION
- [x] Fixed buttons with icons.
- [x] Fixed toast message button icon issue.

**More info:**
Button variant is not directly linked to icon variant. For instance, button of variant `danger` must display icon with `secondary` variant. Hence it requires a mapping. 

Also, the toast-message component uses _ember-cli-flash_ under the hood, which returns specific types such as "Info", "Warning" etc.. While we've followed similar naming conventions in our component, there exists a small problem of capitalisation. To fix this, there are 2 possible solutions:

**Solution#1: Helper**
Create a helper which capitalises the first letter. 
Time complexity: **O(n)**
Space complexity: **O(1)**

**Solution#2: JS Map**
Create a simple mapper like:
```js
const VARIANT_MAP = {
  'Info': 'info',
  'Success': 'success',
  'Warning': 'warning',
  'Danger': 'danger'
};
```
Time complexity: **O(1)** 
Space complexity: **O(n)**

Although the helper seemed like a straight-forward solution at first, creating a modifier function is an overkill for a small component which does not even reuse this functionality. Hence, I'm going with the faster solution.