### PR TITLE
fix(banner): system alerts is not responsive (#122)

### DIFF
--- a/packages/banner/addon/styles/components/_nucleus-banner-item.scss
+++ b/packages/banner/addon/styles/components/_nucleus-banner-item.scss
@@ -18,6 +18,11 @@
     top: 8px;
     right: 16px;
   }
+
+  &__content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .nucleus-banner--mini {

--- a/packages/banner/addon/styles/components/_nucleus-banner.scss
+++ b/packages/banner/addon/styles/components/_nucleus-banner.scss
@@ -34,7 +34,8 @@
       position: absolute;
       top: 40px;
       right: 0;
-      width: 400px;
+      max-width: 400px;
+      width: calc(100vw - 16px);
       background: #fff;
       box-shadow: 0 2px 8px 0 rgba(0, 0, 0, .15);
       padding: 8px;
@@ -117,6 +118,7 @@
   @media screen and (min-width: $mobile-screen-min-width) and (max-width: $mobile-screen-max-width) {
     &__main {
       overflow-x: auto;
+      padding-left: 8px;
     }
   }
 }


### PR DESCRIPTION
#### Description

Resolves #122

The 'System alerts' in Banner has a fixed width of 400px. 
Solution: Setting 'maximum width' to '400px' and 'width' to be calculated based on viewport size. 

Other Minor fixes in PR:
Banner text to overflow with ellipses
Banner text to have left padding for mobile sizes

Before fix:
![image](https://user-images.githubusercontent.com/61269786/75031505-67d07e00-54cc-11ea-900c-fea4c5338e3a.png)

After fix:
![image](https://user-images.githubusercontent.com/61269786/75031522-7880f400-54cc-11ea-84fa-27fd9e05853b.png)

Tested in chrome, firefox and safari

#### Related Bug
