### PR TITLE
modal submit disabled fix

### DIFF
--- a/packages/@nucleus/package.json
+++ b/packages/@nucleus/package.json
@@ -27,7 +27,7 @@
     "@freshworks/datepicker": "^0.2.0",
     "@freshworks/icon": "^0.9.0",
     "@freshworks/inline-banner": "^0.6.5",
-    "@freshworks/modal": "^0.6.6",
+    "@freshworks/modal": "^0.6.7",
     "@freshworks/pagination": "^0.3.0",
     "@freshworks/table": "^0.2.0",
     "@freshworks/tabs": "^0.4.6",

--- a/packages/modal/addon/templates/components/nucleus-modal.hbs
+++ b/packages/modal/addon/templates/components/nucleus-modal.hbs
@@ -22,6 +22,7 @@
           footer=(component "nucleus-modal/footer"
                   type=type
                   submitTitle=submitTitle
+                  submitDisabled=submitDisabled
                   closeTitle=closeTitle
                   onClose=(action "close")
                   onSubmit=(action "submit"))

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshworks/modal",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Modal component in Nucleus",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Submit disabled value is not passed from modal component to button component, Hence we are are not able to disable the submit button. Fixing that by just passing the value to button component.