### PR TITLE
Added xl width for nucleus modal

### DIFF
--- a/packages/modal/addon/styles/components/_nucleus-modal.scss
+++ b/packages/modal/addon/styles/components/_nucleus-modal.scss
@@ -39,6 +39,10 @@ $slider-width: 600px;
     display: flex;
     flex-direction: column;
 
+    &--xlarge {
+      width: 1350px;
+    }
+
     &--large {
       width: 800px;
     }


### PR DESCRIPTION
#### Description
Added xl width for nucleus modal supporting 1350px in width. 

Add `Resolves #<github-issue-id>` if you wish to automatically close the Issue when this PR is merged.

#### Related Bug
